### PR TITLE
Add support for watchOS2

### DIFF
--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.screenshots  = "https://cloud.githubusercontent.com/assets/564725/11452558/17fd5f04-95ec-11e5-96d2-427f62ed4f05.jpg", "https://cloud.githubusercontent.com/assets/564725/11452560/33225d16-95ec-11e5-8461-78f50b9e8da7.jpg"
   s.license      = "MIT"
   s.author       = { "Sebastian Kreutzberger" => "s.kreutzberger@googlemail.com" }
-  s.platform     = :ios, "8.0"
+  s.ios.deployment_target = "8.0"
+  s.watchos.deployment_target = "2.0"
   s.source       = { :git => "https://github.com/skreutzberger/SwiftyBeaver.git", :tag => "v0.2.3" }
   s.source_files  = "sources"
 end


### PR DESCRIPTION
* Add support for watchOS2 extensions

# Testing

* Created new project with a watchOS app
* Added file to Podfile (example below)
* Tested
* Profit :dollar: :moneybag: 

# Example Podfile

```ruby
# Uncomment this line to define a global platform for your project
# platform :ios, '8.0'
# Uncomment this line if you're using Swift
use_frameworks!

target 'Test' do

end

target 'Test WatchKit App' do

end

target 'Test WatchKit Extension' do
        platform :watchos, '2.0'
        pod 'SwiftyBeaver', :path => '../SwiftyBeaver'
end
```